### PR TITLE
fix: validate Cyberint CVE path identifiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/cyberintalerts_connector.py
+++ b/cyberintalerts_connector.py
@@ -41,6 +41,7 @@ from cyberintalerts_consts import (
     Status,
     TakedownReason,
 )
+from cyberintalerts_validation import normalize_cve_id
 
 
 class RetVal(tuple):
@@ -447,7 +448,10 @@ class CyberintAlertsConnector(BaseConnector):
 
     def _handle_get_cve_intelligence(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
-        cve_id = param["CVE_ID"]
+        cve_id = normalize_cve_id(param["CVE_ID"])
+        if cve_id is None:
+            return action_result.set_status(phantom.APP_ERROR, "CVE_ID must use the format CVE-YYYY-NNNN with at least four sequence digits")
+
         endpoint = CVE_GET_BY_ID_ENDPOINT.format(cve_id=cve_id)
         ret_val, response = self._make_rest_call(endpoint, action_result)
         if phantom.is_fail(ret_val):

--- a/cyberintalerts_validation.py
+++ b/cyberintalerts_validation.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import re
+
+
+CVE_ID_PATTERN = re.compile(r"CVE-\d{4}-\d{4,}", re.IGNORECASE)
+
+
+def normalize_cve_id(value):
+    if not isinstance(value, str) or CVE_ID_PATTERN.fullmatch(value) is None:
+        return None
+    return value.upper()

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Validate CVE identifiers before inserting them into Cyberint API paths.
+* Validate CVE identifiers before inserting them into Cyberint API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Validate CVE identifiers before inserting them into Cyberint API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Validate CVE identifiers before inserting them into Cyberint API paths.
+* - Validate CVE identifiers before inserting them into Cyberint API paths.

--- a/tests/test_cyberintalerts_validation.py
+++ b/tests/test_cyberintalerts_validation.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import unittest
+
+from cyberintalerts_validation import normalize_cve_id
+
+
+class NormalizeCveIdTestCase(unittest.TestCase):
+    def test_accepts_and_normalizes_valid_cve_ids(self):
+        self.assertEqual(normalize_cve_id("CVE-2024-1234"), "CVE-2024-1234")
+        self.assertEqual(normalize_cve_id("cve-2025-123456"), "CVE-2025-123456")
+
+    def test_rejects_path_and_query_injection(self):
+        for value in ("CVE-2024-1234/alerts", "../CVE-2024-1234", "CVE-2024-1234?all=true"):
+            with self.subTest(value=value):
+                self.assertIsNone(normalize_cve_id(value))
+
+    def test_rejects_invalid_shapes(self):
+        for value in ("CVE-24-1234", "CVE-2024-123", "", None, 1234):
+            with self.subTest(value=value):
+                self.assertIsNone(normalize_cve_id(value))


### PR DESCRIPTION
## Summary

- require CVE identifiers to match the standard CVE-YYYY-NNNN shape before constructing the API path
- normalize accepted identifiers to uppercase
- reject additional path segments and query components
- add focused unit coverage for valid IDs, invalid shapes, and path/query injection attempts

## Tracking

- PAPP-38151
- Parent epic: ESPM-5228
- PSAAS-31267

## Validation

- local compile: passed
- local unit tests: passed
- local pre-commit and static tests: passed
- hosted pre-commit and compile: pending

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38151
- PSAAS: PSAAS-31267
- Written by Codex.